### PR TITLE
Avoid border issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-moon",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Moon component for React",
   "author": "dlbnco",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const Wrapper = styled.div`
   position: relative;
   transition: transform 1s;
   border-radius: 50%;
+  box-sizing: content-box;
   ${({ size, rotation, darkColor, border }) => css`
     background-color: ${darkColor};
     width: ${size}px;


### PR DESCRIPTION
If the global style was set to use `box-sizing: border-box;`, the moon border would behave weirdly. This sets the moon wrapper to `content-box` to avoid this from happening.

|before|after|
|-|-|
|![image](https://user-images.githubusercontent.com/16964673/66909037-c4022d80-f014-11e9-8b19-610472f1dcf6.png)|![image](https://user-images.githubusercontent.com/16964673/66909076-d1b7b300-f014-11e9-943e-e21e7cefbf22.png)|

_(border in red)_